### PR TITLE
Create better mock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,25 +33,23 @@ Go build will leave a binary in the root directory that can be run.
 	
 ### RUN
 
-Feed it the target collector and port:
+Feed it the target collector and port, and optional "false-index" flag:
 
-	./nflow-generator -t <ip> -p <port>
-
-Or (this doesn't always work - the previous command did work)
-
-	go run nflow-generator.go nflow_logger.go nflow_data.go  -t 172.16.86.138 -p 9995
+	./nflow-generator -t <ip> -p <port> [ -f | --false-index ]
 
 ### Update - May 2017
 
-The original mock netflow generator placed random values in several fields which confused certain netflow collectors.
-Those collectors complained about inaccurate time stamps, 
+The original mock netflow generator placed random values in several fields which confused 
+certain netflow collectors that complained about inaccurate time stamps, 
 and were confused by the random values sent in the input and output interface fields. This update:
 
 * Sets the `SysUptime`, `unix_secs`, and `unix_nsecs` fields of the Netflow datagrams to sensible (UTC) values
 * Generates a unique `flow_sequence` value for each netflow datagram
 * Creates reasonable start/stop times for flows, so the First is set to (now-X) and Last to (now-Y), where X & Y are random times, and X > Y.
-* Sets the interface indexes to 1 or 2 - based on this algorithm. 
+* If the --false-index (-f) flag is set on the command line, 
+use this algorithm to set the interface indexes to 1 or 2:
 If the source address > dest address, input interface is set to 1, and set to 2 otherwise,
 and the output interface is set to the opposite value.
+If the -f is missing, both snmp interface indexes will be set to 0. [Default]
 
 To learn more about Netflow version 5 datagram formats, see the [Cisco Netflow documentation](http://www.cisco.com/c/en/us/td/docs/net_mgmt/netflow_collection_engine/3-6/user/guide/format.html)

--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ Or:
 
 	go run nflow-generator.go nflow_logger.go nflow_data.go  -t 172.16.86.138 -p 9995
 
+### Update - May 2017
+
+The original mock netflow data set random values in several fields which confused certain netflow collectors.
+Those collectors complained about inaccurate time stamps, 
+and were confused by the random values sent in the input and output interface fields. This update:
+
+* Sets the SysUptime, unix_secs, and unix_nsecs fields to sensible (UTC) values
+* Generates a unique flow_sequence value for each netflow datagram
+* Creates reasonable start/stop times for flows, so the First is (now-X) and Last is (now-Y), where X & Y are random times, and X > Y.
+* Sets the interface indexes to 1 or 2 - based on this algorithm. 
+If the source address > dest address, input interface is set to 1, and set to 2 otherwise,
+and the output interface is set to the opposite value.
+
+These are based on the [Cisco Netflow documentation](http://www.cisco.com/c/en/us/td/docs/net_mgmt/netflow_collection_engine/3-6/user/guide/format.html)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-## Usage
+# Usage - nflow-generator
+
+This program generates mock netflow (v5) data that can be used to test netflow collector programs. 
+The program simulates a router that is exporting flow records to the collector.
+It is useful for determining whether the netflow collector is operating and/or receiving netflow datagrams.
+
+nflow-generator generates several netflow datagrams per second, each with 8 or 16 records for varying kinds of traffic (HTTP, SSH, SNMP, DNS, MySQL, and many others.)
 
 ### Docker Image Run (Easiest)
 
@@ -16,9 +22,10 @@ docker run -it --rm networkstatic/nflow-generator -t <ip> -p <port>
 
 ### Build
 
-Install [Go](http://golang.org/doc/install)
+Install [Go](http://golang.org/doc/install), then:
 
-	git clone https://github.com/nerdalert/nflow-generator.git
+	git clone https://github.com/nerdalert/nflow-generator.git -or -
+	git clone https://github.com/richb-hanover/nflow-generator.git
 	cd <dir>
 	go build
 
@@ -30,21 +37,21 @@ Feed it the target collector and port:
 
 	./nflow-generator -t <ip> -p <port>
 
-Or:
+Or (this doesn't always work - the previous command did work)
 
 	go run nflow-generator.go nflow_logger.go nflow_data.go  -t 172.16.86.138 -p 9995
 
 ### Update - May 2017
 
-The original mock netflow data set random values in several fields which confused certain netflow collectors.
+The original mock netflow generator placed random values in several fields which confused certain netflow collectors.
 Those collectors complained about inaccurate time stamps, 
 and were confused by the random values sent in the input and output interface fields. This update:
 
-* Sets the SysUptime, unix_secs, and unix_nsecs fields to sensible (UTC) values
-* Generates a unique flow_sequence value for each netflow datagram
-* Creates reasonable start/stop times for flows, so the First is (now-X) and Last is (now-Y), where X & Y are random times, and X > Y.
+* Sets the `SysUptime`, `unix_secs`, and `unix_nsecs` fields of the Netflow datagrams to sensible (UTC) values
+* Generates a unique `flow_sequence` value for each netflow datagram
+* Creates reasonable start/stop times for flows, so the First is set to (now-X) and Last to (now-Y), where X & Y are random times, and X > Y.
 * Sets the interface indexes to 1 or 2 - based on this algorithm. 
 If the source address > dest address, input interface is set to 1, and set to 2 otherwise,
 and the output interface is set to the opposite value.
 
-These are based on the [Cisco Netflow documentation](http://www.cisco.com/c/en/us/td/docs/net_mgmt/netflow_collection_engine/3-6/user/guide/format.html)
+To learn more about Netflow version 5 datagram formats, see the [Cisco Netflow documentation](http://www.cisco.com/c/en/us/td/docs/net_mgmt/netflow_collection_engine/3-6/user/guide/format.html)

--- a/nflow-generator.go
+++ b/nflow-generator.go
@@ -35,7 +35,8 @@ var opts struct {
 	CollectorIP   string `short:"t" long:"target" description:"target ip address of the netflow collector"`
 	CollectorPort string `short:"p" long:"port" description:"port number of the target netflow collector"`
 	SpikeProto    string `short:"s" long:"spike" description:"run a second thread generating a spike for the specified protocol"`
-	Help          bool   `short:"h" long:"help" description:"show nflow-generator help"`
+    FalseIndex    bool   `short:"f" long:"false-index" description:"generate false SNMP interface indexes, otherwise set to 0"`
+    Help          bool   `short:"h" long:"help" description:"show nflow-generator help"`
 }
 
 func main() {
@@ -107,6 +108,9 @@ func showUsage() {
 Usage:
   main [OPTIONS] [collector IP address] [collector port number]
 
+  Send mock Netflow version 5 data to designated collector IP & port.
+  Time stamps in all datagrams are set to UTC.
+
 Application Options:
   -t, --target= target ip address of the netflow collector
   -p, --port=   port number of the target netflow collector
@@ -124,13 +128,22 @@ Application Options:
         https_alt - generates tcp/8080
         p2p - generates udp/6681
         bittorrent - generates udp/6682
+  -f, --false-index generate false snmp index values of 1 or 2: If the source address > dest address, input interface is set to 1, and set to 2 otherwise,
+and the output interface is set to the opposite value. Default in and out interface is 0. (Optional)
 
-Example:
-    -generate default flows:
-    ./nflow-generator.go -t 172.16.86.138 -p 9995
+Example Usage:
+
+    -first build from source (one time)
+    go build   
+
+    -generate default flows to device 172.16.86.138, port 9995
+    ./nflow-generator -t 172.16.86.138 -p 9995 
 
     -generate default flows along with a spike in the specified protocol:
     ./nflow-generator -t 172.16.86.138 -p 9995 -s ssh
+
+    -generate default flows with "false index" settings for snmp interfaces 
+    ./nflow-generator -t 172.16.86.138 -p 9995 -f
 
 Help Options:
   -h, --help    Show this help message

--- a/nflow_payload.go
+++ b/nflow_payload.go
@@ -116,7 +116,7 @@ func CreateNFlowHeader(recordCount int) NetflowHeader {
 	t := time.Now().UnixNano()
 	sec := t / int64(time.Second)
 	nsec := t - sec*int64(time.Second)
-	sysUptime = uint32((t-StartTime) / int64(time.Millisecond))
+	sysUptime = uint32((t-StartTime) / int64(time.Millisecond))+1000
 	flowSequence++
 
 	// log.Infof("Time: %d; Seconds: %d; Nanoseconds: %d\n", t, sec, nsec)
@@ -194,6 +194,7 @@ func CreateIcmpFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -217,6 +218,7 @@ func CreateHttpFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -240,6 +242,7 @@ func CreateSnmpFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -262,6 +265,7 @@ func CreateFTPFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -285,6 +289,7 @@ func CreateNtpFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(32)
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -309,6 +314,7 @@ func CreateP2pFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(32)
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -334,6 +340,7 @@ func CreateBitorrentFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(32)
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -359,6 +366,7 @@ func CreateSshFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -384,6 +392,7 @@ func CreateHttpsFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -409,6 +418,7 @@ func CreateHttpAltFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -434,6 +444,7 @@ func CreateDnsFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -459,6 +470,7 @@ func CreateImapsFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -484,6 +496,7 @@ func CreateMySqlFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
 	return *payload
 }
 
@@ -509,6 +522,27 @@ func CreateRandomFlow() NetflowPayload {
 	payload.SrcPrefixMask = uint8(rand.Intn(32))
 	payload.DstPrefixMask = uint8(rand.Intn(32))
 	payload.Padding2 = 0
+	FixIFTimes(payload)
+	return *payload
+}
+
+// patch up the SnmpInIndex and SnmpOutIndex, and the start/end times for the flows
+func FixIFTimes(payload *NetflowPayload) NetflowPayload {
+
+	if payload.SrcIP > payload.DstIP {
+		payload.SnmpInIndex = 1
+		payload.SnmpOutIndex = 2
+	} else {
+		payload.SnmpInIndex = 2
+		payload.SnmpOutIndex = 1
+	}
+	uptime := int(sysUptime)
+	payload.SysUptimeEnd = uint32(uptime - randomNum(10,500))
+	payload.SysUptimeStart = payload.SysUptimeEnd - uint32(randomNum(10,500))
+
+	// log.Infof("S&D : %x %x %d, %d", payload.SrcIP, payload.DstIP, payload.DstPort, payload.SnmpInIndex)
+	// log.Infof("Time: %d %d %d", sysUptime, payload.SysUptimeStart, payload.SysUptimeEnd)
+
 	return *payload
 }
 

--- a/nflow_payload.go
+++ b/nflow_payload.go
@@ -159,6 +159,7 @@ func CreateNFlowPayload(recordCount int) []NetflowPayload {
 		payload[1] = CreateHttpsFlow()
 		payload[2] = CreateHttpAltFlow()
 		payload[3] = CreateDnsFlow()
+		payload[4] = CreateIcmpFlow()
 		payload[5] = CreateNtpFlow()
 		payload[6] = CreateImapsFlow()
 		payload[7] = CreateMySqlFlow()
@@ -169,7 +170,7 @@ func CreateNFlowPayload(recordCount int) []NetflowPayload {
 		payload[12] = CreateFTPFlow()
 		payload[13] = CreateSnmpFlow()
 		payload[14] = CreateIcmpFlow()
-		payload[14] = CreateRandomFlow()
+		payload[15] = CreateRandomFlow()
 	}
 	return payload
 }
@@ -182,19 +183,19 @@ func CreateIcmpFlow() NetflowPayload {
 	payload.NextHopIP = IPtoUint32("132.12.130.1")
 	payload.SrcPort = 0
 	payload.DstPort = 0
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_SM)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_SM)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 1
-	payload.IpTos = 0
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_SM)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_SM)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 1
+	// payload.IpTos = 0
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_SM, 1, rand.Intn(32))
 	return *payload
 }
 
@@ -202,23 +203,23 @@ func CreateIcmpFlow() NetflowPayload {
 func CreateHttpFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 	payload.SrcIP = IPtoUint32("112.10.20.10")
-	payload.DstIP = IPtoUint32("162.12.190.10")
+	payload.DstIP = IPtoUint32("172.30.190.10")
 	payload.NextHopIP = IPtoUint32("172.199.15.1")
 	payload.SrcPort = uint16(40)
 	payload.DstPort = uint16(HTTP_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 6
-	payload.IpTos = 0
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 6
+	// payload.IpTos = 0
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 6, rand.Intn(32))
 	return *payload
 }
 
@@ -226,199 +227,199 @@ func CreateHttpFlow() NetflowPayload {
 func CreateSnmpFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 	payload.SrcIP = IPtoUint32("112.10.20.10")
-	payload.DstIP = IPtoUint32("162.12.190.10")
+	payload.DstIP = IPtoUint32("172.30.190.10")
 	payload.NextHopIP = IPtoUint32("172.199.15.1")
 	payload.SrcPort = uint16(40)
 	payload.DstPort = uint16(SNMP_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 17
-	payload.IpTos = 0
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 17
+	// payload.IpTos = 0
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 17, rand.Intn(32))
 	return *payload
 }
 
 func CreateFTPFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 	payload.SrcIP = IPtoUint32("112.10.100.10")
-	payload.DstIP = IPtoUint32("182.12.120.10")
+	payload.DstIP = IPtoUint32("192.168.120.10")
 	payload.NextHopIP = IPtoUint32("172.199.15.1")
 	payload.SrcPort = uint16(40)
 	payload.DstPort = uint16(FTP_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 6
-	payload.IpTos = 0
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 6
+	// payload.IpTos = 0
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 6, rand.Intn(32))
 	return *payload
 }
 
 func CreateNtpFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 	payload.SrcIP = IPtoUint32("247.104.20.202")
-	payload.DstIP = IPtoUint32("42.12.190.10")
+	payload.DstIP = IPtoUint32("10.12.190.10")
 	payload.NextHopIP = IPtoUint32("192.199.15.1")
 	payload.SrcPort = uint16(40)
 	payload.DstPort = uint16(NTP_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 17
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
-	payload.SrcPrefixMask = uint8(32)
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 17
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SrcPrefixMask = uint8(32)
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 17, 32)
 	return *payload
 }
 
 func CreateP2pFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 	payload.SrcIP = IPtoUint32("247.104.20.202")
-	payload.DstIP = IPtoUint32("42.12.190.10")
+	payload.DstIP = IPtoUint32("10.12.190.10")
 	payload.NextHopIP = IPtoUint32("192.199.15.1")
 	payload.SrcPort = uint16(40)
 	payload.DstPort = uint16(P2P_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 17
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 17
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
 
-	payload.SrcPrefixMask = uint8(32)
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SrcPrefixMask = uint8(32)
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 17, 32)
 	return *payload
 }
 
 func CreateBitorrentFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 
-	payload.SrcIP = IPtoUint32("247.104.20.202")
+	payload.SrcIP = IPtoUint32("192.168.20.202")
 	payload.DstIP = IPtoUint32("42.12.190.10")
 	payload.NextHopIP = IPtoUint32("192.199.15.1")
 	payload.SrcPort = uint16(40)
 	payload.DstPort = uint16(BITTORRENT_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 17
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 17
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
 
-	payload.SrcPrefixMask = uint8(32)
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SrcPrefixMask = uint8(32)
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 17, 32)
 	return *payload
 }
 
 func CreateSshFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 
-	payload.SrcIP = IPtoUint32("147.104.20.102")
+	payload.SrcIP = IPtoUint32("172.30.20.102")
 	payload.DstIP = IPtoUint32("222.12.190.10")
 	payload.NextHopIP = IPtoUint32("192.199.15.1")
 	payload.SrcPort = uint16(40)
 	payload.DstPort = uint16(SSH_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 6
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 6
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
 
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 6, rand.Intn(32))
 	return *payload
 }
 
 func CreateHttpsFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 
-	payload.SrcIP = IPtoUint32("182.10.20.10")
+	payload.SrcIP = IPtoUint32("192.168.20.10")
 	payload.DstIP = IPtoUint32("202.12.190.10")
 	payload.NextHopIP = IPtoUint32("172.199.15.1")
 	payload.SrcPort = uint16(40)
 	payload.DstPort = uint16(HTTPS_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 6
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 6
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
 
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 6, rand.Intn(32))
 	return *payload
 }
 
 func CreateHttpAltFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 
-	payload.SrcIP = IPtoUint32("12.10.20.122")
+	payload.SrcIP = IPtoUint32("10.10.20.122")
 	payload.DstIP = IPtoUint32("84.12.190.210")
 	payload.NextHopIP = IPtoUint32("192.199.15.1")
 	payload.SrcPort = uint16(12001)
 	payload.DstPort = uint16(HTTPS_ALT_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 6
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 6
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
 
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 6, rand.Intn(32))
 	return *payload
 }
 
@@ -426,77 +427,77 @@ func CreateDnsFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 
 	payload.SrcIP = IPtoUint32("59.220.158.122")
-	payload.DstIP = IPtoUint32("6.12.233.210")
+	payload.DstIP = IPtoUint32("10.12.233.210")
 	payload.NextHopIP = IPtoUint32("39.199.15.1")
 	payload.SrcPort = uint16(9221)
 	payload.DstPort = uint16(DNS_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 17
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 17
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
 
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 17, rand.Intn(32))
 	return *payload
 }
 
 func CreateImapsFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 
-	payload.SrcIP = IPtoUint32("171.104.20.102")
+	payload.SrcIP = IPtoUint32("172.30.20.102")
 	payload.DstIP = IPtoUint32("62.12.190.10")
 	payload.NextHopIP = IPtoUint32("131.199.15.1")
 	payload.SrcPort = uint16(9010)
 	payload.DstPort = uint16(IMAPS_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 6
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 6
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
 
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 6, rand.Intn(32))
 	return *payload
 }
 
 func CreateMySqlFlow() NetflowPayload {
 	payload := new(NetflowPayload)
 
-	payload.SrcIP = IPtoUint32("42.154.20.12")
+	payload.SrcIP = IPtoUint32("10.154.20.12")
 	payload.DstIP = IPtoUint32("77.12.190.94")
 	payload.NextHopIP = IPtoUint32("150.20.145.1")
 	payload.SrcPort = uint16(9010)
 	payload.DstPort = uint16(MYSQL_PORT)
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
-	payload.Padding1 = 0
-	payload.IpProtocol = 6
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 6
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
 
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 6, rand.Intn(32))
 	return *payload
 }
 
@@ -506,36 +507,67 @@ func CreateRandomFlow() NetflowPayload {
 	payload.SrcIP = rand.Uint32()
 	payload.DstIP = rand.Uint32()
 	payload.NextHopIP = rand.Uint32()
-	payload.SnmpInIndex = genRandUint16(UINT16_MAX)
-	payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
-	payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
-	payload.SysUptimeStart = rand.Uint32()
-	payload.SysUptimeEnd = rand.Uint32()
 	payload.SrcPort = genRandUint16(UINT16_MAX)
 	payload.DstPort = genRandUint16(UINT16_MAX)
-	payload.Padding1 = 0
-	payload.IpProtocol = 6
-	payload.IpTos = 0
-	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	// payload.NumPackets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.NumOctets = genRandUint32(PAYLOAD_AVG_MD)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	// payload.Padding1 = 0
+	// payload.IpProtocol = 6
+	// payload.IpTos = 0
+	// payload.SrcAsNumber = genRandUint16(UINT16_MAX)
 
-	payload.SrcPrefixMask = uint8(rand.Intn(32))
-	payload.DstPrefixMask = uint8(rand.Intn(32))
-	payload.Padding2 = 0
-	FixIFTimes(payload)
+	// payload.SrcPrefixMask = uint8(rand.Intn(32))
+	// payload.DstPrefixMask = uint8(rand.Intn(32))
+	// payload.Padding2 = 0
+	FillCommonFields(payload, PAYLOAD_AVG_MD, 6, rand.Intn(32))
 	return *payload
 }
 
-// patch up the SnmpInIndex and SnmpOutIndex, and the start/end times for the flows
-func FixIFTimes(payload *NetflowPayload) NetflowPayload {
+// patch up the common fields of the packets
+func FillCommonFields (
+		payload *NetflowPayload, 
+		numPktOct int, 
+		ipProtocol int, 
+		srcPrefixMask int) NetflowPayload {
 
-	if payload.SrcIP > payload.DstIP {
+// Fill template with values not filled by caller
+	// payload.SrcIP = IPtoUint32("10.154.20.12")
+	// payload.DstIP = IPtoUint32("77.12.190.94")
+	// payload.NextHopIP = IPtoUint32("150.20.145.1")
+	// payload.SrcPort = uint16(9010)
+	// payload.DstPort = uint16(MYSQL_PORT)
+	// payload.SnmpInIndex = genRandUint16(UINT16_MAX)
+	// payload.SnmpOutIndex = genRandUint16(UINT16_MAX)
+	payload.NumPackets = genRandUint32(numPktOct)
+	payload.NumOctets = genRandUint32(numPktOct)
+	// payload.SysUptimeStart = rand.Uint32()
+	// payload.SysUptimeEnd = rand.Uint32()
+	payload.Padding1 = 0
+	payload.IpProtocol = uint8(ipProtocol)
+	payload.IpTos = 0
+	payload.SrcAsNumber = genRandUint16(UINT16_MAX)
+	payload.DstAsNumber = genRandUint16(UINT16_MAX)
+
+	payload.SrcPrefixMask = uint8(srcPrefixMask)
+	payload.DstPrefixMask = uint8(rand.Intn(32))
+	payload.Padding2 = 0
+
+	// now handle computed values
+	if !opts.FalseIndex {                       // default interfaces are zero
+		payload.SnmpInIndex = 0
+		payload.SnmpOutIndex = 0
+	} else if payload.SrcIP > payload.DstIP {   // false-index
 		payload.SnmpInIndex = 1
 		payload.SnmpOutIndex = 2
 	} else {
 		payload.SnmpInIndex = 2
 		payload.SnmpOutIndex = 1
 	}
+
 	uptime := int(sysUptime)
 	payload.SysUptimeEnd = uint32(uptime - randomNum(10,500))
 	payload.SysUptimeStart = payload.SysUptimeEnd - uint32(randomNum(10,500))


### PR DESCRIPTION
This PR updates nflow-generator to create better mock data. This includes:

- Each flow datagram has a unique flowSequence.
- All flow datagrams have definite (non-random) SysUptime and unix_sec and unix_nsec UTC time stamps.
- Each flow within a datagram, individual flows each have reasonable first/last time stamps.
- There is a "false index" command-line flag (-f) that sets input and output interfaces to 1 and 2 if true; 0 otherwise.
- Assorted tweaks to the datagrams to ensure the flow data is sensible, and without missing data.