### PR TITLE
Use Go modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+binaries
+.gitignore
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Brent Salisbury <brent.salisbury@gmail.com>
 
 ADD . /go/src/github.com/nerdalert/nflow-generator
 
-RUN go get github.com/Sirupsen/logrus \
-    && go get github.com/jessevdk/go-flags \
-    && go install github.com/nerdalert/nflow-generator
+WORKDIR /etc/nflow
+COPY . .
+RUN go build .
 
-ENTRYPOINT ["/go/bin/nflow-generator"]
+ENTRYPOINT ["/etc/nflow/nflow-generator"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/nerdalert/nflow-generator
+
+go 1.15
+
+require (
+	github.com/jessevdk/go-flags v1.5.0
+	github.com/sirupsen/logrus v1.8.1
+	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e h1:XMgFehsDnnLGtjvjOfqWSUzt0alpTR1RSEuznObga2c=
+golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/nflow_logging.go
+++ b/nflow_logging.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var log = logrus.New()


### PR DESCRIPTION
I've implemented support for Go modules so that the dependencies etc. are versioned to maintain future operability of the utility. With the change I've also changed the Dockerfile to make it use the source itself to build the same version you would have locally.