### PR TITLE
Use alpine for image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM golang
+FROM golang:alpine as build
+COPY . /src
+WORKDIR /src
+RUN go build -v .
 
+FROM alpine:latest
 MAINTAINER Brent Salisbury <brent.salisbury@gmail.com>
 
-ADD . /go/src/github.com/nerdalert/nflow-generator
-
-WORKDIR /etc/nflow
-COPY . .
-RUN go build .
-
-ENTRYPOINT ["/etc/nflow/nflow-generator"]
+COPY --from=build /src/nflow-generator /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/nflow-generator"]


### PR DESCRIPTION
This updates the `Dockerfile` to use Alpine for build and image.

```
ehazlett/nflow-generator        latest    1c6091c56dfa   4 hours ago    8.59MB
networkstatic/nflow-generator   latest    37af5e2a0beb   2 months ago   966MB
```